### PR TITLE
Add a couple tests for query with filter and layer options

### DIFF
--- a/test/integration/query-tests/filter/equals-filter/expected.json
+++ b/test/integration/query-tests/filter/equals-filter/expected.json
@@ -1,0 +1,19 @@
+[
+  { 
+    "type": "Feature", 
+    "id": "feature1",
+    "geometry": { 
+      "type": "Point",
+      "coordinates": [
+        0.0,
+        0.0
+      ] 
+    }, 
+    "properties": {
+      "key1": "value1",
+      "key2": 1.5,
+      "key3": false,
+      "key4": 0.5
+    } 
+  }
+]

--- a/test/integration/query-tests/filter/equals-filter/style.json
+++ b/test/integration/query-tests/filter/equals-filter/style.json
@@ -1,0 +1,53 @@
+{
+  "version": 8,
+  "metadata": {
+    "test": {
+      "width": 10,
+      "height": 10,
+      "queryGeometry": [
+        5,
+        5
+      ], 
+      "queryOptions": {
+        "filter": ["==", "key1", "value1" ]
+      },
+      "ignored": {
+        "js" : true
+      }
+    }
+  },
+  "center": [
+    0.0,
+    0.0
+  ],
+  "zoom": 0,
+  "sources": {
+    "source1": {
+      "type": "geojson",
+      "data": { 
+        "type": "Feature", 
+        "id": "feature1",
+        "geometry": { 
+          "type": "Point",
+          "coordinates": [
+            0.0,
+            0.0
+          ] 
+        }, 
+        "properties": {
+          "key1": "value1",
+          "key2": 1.5,
+          "key3": false,
+          "key4": 0.5
+        } 
+      }
+    }
+  },
+  "layers": [
+    {
+      "id": "layer4",
+      "type": "circle",
+      "source": "source1"
+    }
+  ]
+}

--- a/test/integration/query-tests/filter/layer-filter/expected.json
+++ b/test/integration/query-tests/filter/layer-filter/expected.json
@@ -1,0 +1,19 @@
+[
+  { 
+    "type": "Feature", 
+    "id": "feature1",
+    "geometry": { 
+      "type": "Point",
+      "coordinates": [
+        0.0,
+        0.0
+      ] 
+    }, 
+    "properties": {
+      "key1": "value1",
+      "key2": 1.5,
+      "key3": false,
+      "key4": 0.5
+    } 
+  }
+]

--- a/test/integration/query-tests/filter/layer-filter/style.json
+++ b/test/integration/query-tests/filter/layer-filter/style.json
@@ -1,0 +1,79 @@
+{
+  "version": 8,
+  "metadata": {
+    "test": {
+      "width": 10,
+      "height": 10,
+      "queryGeometry": [
+        5,
+        5
+      ], 
+      "queryOptions": {
+        "filter": ["has", "key1" ],
+        "layers": ["layer4"]
+      },
+      "ignored": {
+        "js" : true
+      }
+    }
+  },
+  "center": [
+    0.0,
+    0.0
+  ],
+  "zoom": 0,
+  "sources": {
+    "source1": {
+      "type": "geojson",
+      "data": { 
+        "type": "Feature", 
+        "id": "feature1",
+        "geometry": { 
+          "type": "Point",
+          "coordinates": [
+            0.0,
+            0.0
+          ] 
+        }, 
+        "properties": {
+          "key1": "value1",
+          "key2": 1.5,
+          "key3": false,
+          "key4": 0.5
+        } 
+      }
+    },
+    "source2": {
+      "type": "geojson",
+      "data": { 
+        "type": "Feature", 
+        "id": "feature2",
+        "geometry": { 
+          "type": "Point",
+          "coordinates": [
+            0.0,
+            0.0
+          ] 
+        }, 
+        "properties": {
+          "key1": "value2",
+          "key2": 0.5,
+          "key3": true,
+          "key4": 1.5
+        } 
+      }
+    }
+  },
+  "layers": [
+    {
+      "id": "layer4",
+      "type": "circle",
+      "source": "source1"
+    },
+    {
+      "id": "layer3",
+      "type": "circle",
+      "source": "source2"
+    }
+  ]
+}

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -68,7 +68,7 @@ module.exports = function(style, options, _callback) {
             }
 
             const results = options.queryGeometry ?
-                map.queryRenderedFeatures(options.queryGeometry, options) :
+                map.queryRenderedFeatures(options.queryGeometry, options.queryOptions ? options.queryOptions: {}) :
                 [];
 
             map.remove();


### PR DESCRIPTION
This PR is part of addressing issue [7319](https://github.com/mapbox/mapbox-gl-native/issues/7319) in [mapbox-gl-native|https://github.com/asheemmamoowala/mapbox-gl-native/tree/7319-query-with-filter]. 

[Map.queryRenderedFeatures](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures) allows passing layer and filter parameters but did not include any integration tests for these. I've added a couple sanity tests for these parameters. The tests are exercised in the fork linked above, but ignored in mapbox-gl-js. Additional work is needed to make these tests pass in mapbox-gl-js. 
